### PR TITLE
Update failure message to be more descriptive

### DIFF
--- a/find-bundle.sh
+++ b/find-bundle.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ ! -d /usr/share/clear/allbundles ]; then
-	echo "allbundles not found; please install it."
+	echo "allbundles directory not found; please add the os-core-update-index bundle."
 else
 	grep -v "completions" /usr/share/clear/allbundles/* | grep "/usr/bin.*\\W"$1"\\W"
 fi


### PR DESCRIPTION
Since you cannot install anything called "allbundles" specify the
actual bundle the user is expected to add.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>